### PR TITLE
Rename roost-master to roost-controlplane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ hipstershop-ecommerce/src/recommendationservice/grpc_health_probe-linux-amd64
 hipstershop-ecommerce/src/shippingservice/grpc_health_probe-linux-amd64
 
 grpcExample/bin/**
+
+.roost_config.json

--- a/collaborate/README.md
+++ b/collaborate/README.md
@@ -1,6 +1,6 @@
 # Dependent microservices for collaborate feature in ROOST
 
-Two containerised services `fetcher` and `retriver` run in kubernetes environment in two pods. `fetcher` services expose an api at <http://roost-master:30047/articles?tag=kubernetes> to fetch latest articles from <http://dev.to> based on provided tags and stores in provisioned pod volume. `retriver` service is dependent on `fetcher` service to retrieve stored articles in `fetcher` service volume. As soon as articles file is found, `retriever` service reads the content and sends output over HTTP/browser.
+Two containerised services `fetcher` and `retriver` run in kubernetes environment in two pods. `fetcher` services expose an api at <http://roost-controlplane:30047/articles?tag=kubernetes> to fetch latest articles from <http://dev.to> based on provided tags and stores in provisioned pod volume. `retriver` service is dependent on `fetcher` service to retrieve stored articles in `fetcher` service volume. As soon as articles file is found, `retriever` service reads the content and sends output over HTTP/browser.
 
 ## Commands to deploy
 
@@ -32,7 +32,7 @@ make dockerise
 3. Above content must be served by `retriever` service.
 
     ```bash
-        curl "http://roost-master:30048/articles?tag=kubernetes"
+        curl "http://roost-controlplane:30048/articles?tag=kubernetes"
         # --tail n: shows last n lines from logs
         kubectl logs collab-retriever --tail 400
     ```

--- a/googlebookapi/README.md
+++ b/googlebookapi/README.md
@@ -45,12 +45,12 @@ kubectl logs service/googlebookapi --namespace default --tail 400
 * The digit should not have any special characters in between.
 
 > Using any browser
-* Open http://roost-master:30045/books/<isbn\>
->>sample URL: http://roost-master:30045/books/9788126568772
+* Open http://roost-controlplane:30045/books/<isbn\>
+>>sample URL: http://roost-controlplane:30045/books/9788126568772
 
 > Using RKT Konsole
-  * curl http://roost-master:30045/books/<isbn\>
-  >>sample URL: http://roost-master:30045/books/9788126568772
+  * curl http://roost-controlplane:30045/books/<isbn\>
+  >>sample URL: http://roost-controlplane:30045/books/9788126568772
 
 ``` 
 Raise any issue or feature request using RDE Help

--- a/hipstershop-ecommerce/README.md
+++ b/hipstershop-ecommerce/README.md
@@ -76,4 +76,4 @@ Find **Protocol Buffers Descriptions** at the [`./pb` directory](./pb).
 ```
 
 > Run `kubectl get pods` to verify the Pods are ready and running. The
-   application frontend should be available at http://roost-master:30046 .
+   application frontend should be available at http://roost-controlplane:30046 .

--- a/hipstershop-ecommerce/kubernetes-manifests/README.md
+++ b/hipstershop-ecommerce/kubernetes-manifests/README.md
@@ -10,6 +10,6 @@ pre-built public images.
 ## To deploy in ZKE cluster
 
 Use [/kubernetes-manifests/zke-deployment.yaml](/kubernetes-manifests)
-Application can open in browser over http://roost-master:30046
+Application can open in browser over http://roost-controlplane:30046
 
 >_Note:_ Applicaiton is exposed over nodePort 30046

--- a/my-go-project/README.md
+++ b/my-go-project/README.md
@@ -34,7 +34,7 @@ kubectl logs service/myapp
 
 > Using browser
 
-* Open <http://roost-master:30047>
+* Open <http://roost-controlplane:30047>
 
 ### Following are valid `make` commands
 
@@ -64,19 +64,19 @@ Dockerise app with `multistage build and scratch` as base image
 make build-image-html-scratch
 ```
 
-Run application with `html:golang` image (accessible at [http://roost-master:30047](http://roost-master:30047))
+Run application with `html:golang` image (accessible at [http://roost-controlplane:30047](http://roost-controlplane:30047))
 
 ```bash
 make docker-run-html-golang
 ```
 
-Run application with `html:alpine` image (accessible at [http://roost-master:30047](http://roost-master:30047))
+Run application with `html:alpine` image (accessible at [http://roost-controlplane:30047](http://roost-controlplane:30047))
 
 ```bash
 make docker-run-html-alpine
 ```
 
-Run application with `html:scratch` image (accessible at [http://roost-master:30047](http://roost-master:30047))
+Run application with `html:scratch` image (accessible at [http://roost-controlplane:30047](http://roost-controlplane:30047))
 
 ```bash
 make docker-run-html-scratch

--- a/my-go-project/main.go
+++ b/my-go-project/main.go
@@ -27,7 +27,7 @@ func viewHandler(writer http.ResponseWriter, request *http.Request) {
 
 func main() {
 	log.Printf("Serving at port: %s.", appPort)
-	log.Printf("Deployment port may differ from application port. If running from RDE, access app in browser at: %s", "http://roost-master:30047")
+	log.Printf("Deployment port may differ from application port. If running from RDE, access app in browser at: %s", "http://roost-controlplane:30047")
 	http.HandleFunc("/", viewHandler)
 	http.ListenAndServe(net.JoinHostPort("", appPort), nil)
 }


### PR DESCRIPTION
README.md are updated to update name from roost-master to roost-controlplane